### PR TITLE
Credits

### DIFF
--- a/lib/about-view.coffee
+++ b/lib/about-view.coffee
@@ -44,13 +44,15 @@ class AboutView extends ScrollView
               package for details and instructions to disable it.
             '''
         @div class: 'about-credits', outlet: 'credits', =>
+          @span class: 'inline', 'Thanks to the '
+          @a href: 'https://github.com/atom/atom/contributors', 'Atom Community'
+
+        @div class: 'about-love', outlet: 'love', =>
           @span class: 'icon icon-code'
           @span class: 'inline', ' with '
           @span class: 'icon icon-heart'
           @span class: 'inline', ' by '
           @a class: 'icon icon-logo-github', href: 'https://github.com'
-          @span class: 'inline', ' and the '
-          @a href: 'https://github.com/atom/atom/contributors', 'Atom Community'
 
   onDidChangeTitle: -> new Disposable ->
   onDidChangeModified: -> new Disposable ->

--- a/styles/about.less
+++ b/styles/about.less
@@ -115,6 +115,12 @@
   .about-credits {
     margin-top: 40px;
     text-align: center;
+  }
+
+  .about-love {
+    margin-top: 40px;
+    text-align: center;
+    font-size: .86em;
 
     .icon::before {
       // Make these octicons look good inlined with text


### PR DESCRIPTION
This PR splits the `<> with <3 by GitHub` and the credits.

![screen shot 2015-07-10 at 6 00 54 pm](https://cloud.githubusercontent.com/assets/378023/8615453/a409463a-272d-11e5-8634-302f312f0da7.png)

I think the `<> with <3 by GitHub` should stay on its own since it's almost like a logo. But I'm also not sure about the "Thanks to the Atom Community". Giving fair credits to the community is hard since it shouldn't just link to the `atom/atom` contributors, but also include the other community packages and themes.

Maybe it could be:

> Thanks to the [Core contributors](https://github.com/atom/atom/graphs/contributors) and [packages](https://atom.io/packages/)/[themes](https://atom.io/themes/) authors.